### PR TITLE
Release for v0.1.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.1.44](https://github.com/takutakahashi/oci-image-operator/compare/v0.1.43...v0.1.44) - 2023-07-11
+- fix detect: no change to False on CheckedCondition by @takutakahashi in https://github.com/takutakahashi/oci-image-operator/pull/55
+
 ## [v0.1.43](https://github.com/takutakahashi/oci-image-operator/compare/v0.1.42...v0.1.43) - 2023-07-11
 - Fix bug delete deploy by @takutakahashi in https://github.com/takutakahashi/oci-image-operator/pull/52
 


### PR DESCRIPTION
This pull request is for the next release as v0.1.44 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.44 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.43" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix detect: no change to False on CheckedCondition by @takutakahashi in https://github.com/takutakahashi/oci-image-operator/pull/55


**Full Changelog**: https://github.com/takutakahashi/oci-image-operator/compare/v0.1.43...v0.1.44