### PR TITLE
Release for v0.1.48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [v0.1.48](https://github.com/takutakahashi/oci-image-operator/compare/v0.1.47...v0.1.48) - 2023-07-20
+
 ## [v0.1.47](https://github.com/takutakahashi/oci-image-operator/compare/v0.1.46...v0.1.47) - 2023-07-20
 - Cancel staled build by @takutakahashi in https://github.com/takutakahashi/oci-image-operator/pull/62
 


### PR DESCRIPTION
This pull request is for the next release as v0.1.48 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.48 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.47" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->



**Full Changelog**: https://github.com/takutakahashi/oci-image-operator/compare/v0.1.47...v0.1.48